### PR TITLE
Fix React build paths

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Dubbing AI</title>
+</head>
+<body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+</body>
+</html>

--- a/frontend/src/app.jsx
+++ b/frontend/src/app.jsx
@@ -1,5 +1,5 @@
 import { RouterProvider } from "react-router-dom";
-import routes from "./routes.jsx";
+import routes from "./routers.jsx";
 
 export default function App() {
   return <RouterProvider router={routes} />;

--- a/frontend/src/components/PipelineButtons.jsx
+++ b/frontend/src/components/PipelineButtons.jsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import {
   runASR, runScriptProcess, runTTS,
   runLipSync, runMixing, runFinalOutput
-} from "../api.js";
+} from "../api.jsx";
 
 export default function PipelineButtons({ project }) {
   const [log, setLog] = useState("");

--- a/frontend/src/components/UploadPage.jsx
+++ b/frontend/src/components/UploadPage.jsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { uploadVideo } from "../api.js";
+import { uploadVideo } from "../api.jsx";
 
 export default function UploadPage({ onUploaded }) {
   const [title, setTitle] = useState("");

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,3 @@
+body {
+  font-family: sans-serif;
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
-import App from "./App.jsx";
+import App from "./app.jsx";
 import "./index.css";
 
 ReactDOM.createRoot(document.getElementById("root")).render(

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { listProjects } from "../api.js";
+import { listProjects } from "../api.jsx";
 import UploadPage from "../components/UploadPage.jsx";
 import ProjectCard from "../components/ProjectCard.jsx";
 

--- a/frontend/src/pages/ProjectDetail.jsx
+++ b/frontend/src/pages/ProjectDetail.jsx
@@ -1,6 +1,6 @@
 import { useParams } from "react-router-dom";
 import { useState, useEffect } from "react";
-import api from "../api.js";
+import api from "../api.jsx";
 import PipelineButtons from "../components/PipelineButtons.jsx";
 import VideoPlayer from "../components/VideoPlayer.jsx";
 


### PR DESCRIPTION
## Summary
- add missing `index.html` and `index.css` for Vite
- move `Pages` into `src/pages`
- fix import paths in React files

## Testing
- `npm run build`
- `yt-dlp -f best -o sample.mp4 "https://youtu.be/-oxBBZCHli0?si=2ENZY7KlPnoVrl1a"` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68430fc7b0f8832daad6b227f6c5b264