### PR TITLE
Fix module path for Docker startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,4 @@ RUN adduser -u 5678 --disabled-password --gecos "" appuser && chown -R appuser /
 USER appuser
 
 # During debugging, this entry point will be overridden. For more information, please refer to https://aka.ms/vscode-docker-python-debug
-CMD ["gunicorn", "--bind", "0.0.0.0:8000", "-k", "uvicorn.workers.UvicornWorker", "backend.app/main:app"]
+CMD ["gunicorn", "--bind", "0.0.0.0:8000", "-k", "uvicorn.workers.UvicornWorker", "backend.app.main:app"]

--- a/docker-compose.debug.yml
+++ b/docker-compose.debug.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: .
       dockerfile: ./Dockerfile
-    command: ["sh", "-c", "pip install debugpy -t /tmp && python /tmp/debugpy --wait-for-client --listen 0.0.0.0:5678 -m uvicorn backend.app/main:app --host 0.0.0.0 --port 8000"]
+    command: ["sh", "-c", "pip install debugpy -t /tmp && python /tmp/debugpy --wait-for-client --listen 0.0.0.0:5678 -m uvicorn backend.app.main:app --host 0.0.0.0 --port 8000"]
     ports:
       - 8000:8000
       - 5678:5678


### PR DESCRIPTION
## Summary
- correct Python module path in `Dockerfile` CMD
- update debug compose config to use the proper module dotted path

## Testing
- `python -m pip install -r requirements.txt`
- `python -m py_compile backend/app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_684675c7226c832da21a0437d4980645